### PR TITLE
onPointerDown selection and dragging: make wrapper selectable solution

### DIFF
--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,11 +45,13 @@ function Page() {
 	}, [ setBackgroundClickHandler, clearSelection ] );
 
 	const handleSelectElement = useCallback( ( elId, evt ) => {
+		console.log('handleSelectElement:', elId, evt);
 		if ( evt.metaKey ) {
 			toggleElementIdInSelection( elId );
 		} else {
 			selectElementById( elId );
 		}
+		setTargetEl(evt.currentTarget);
 		evt.stopPropagation();
 	}, [ toggleElementIdInSelection, selectElementById ] );
 
@@ -64,31 +66,30 @@ function Page() {
 				return (
 					<Element
 						key={ id }
+						draggable={ false }
 						onClick={ ( evt ) => handleSelectElement( id, evt ) }
+						onPointerDown={ ( evt ) => {
+							if ( ! isSelected ) {
+								handleSelectElement( id, evt );
+								// Setting target directly works, however, it doesn't get updated information from the selected elements state.
+								// setTargetEl( evt.currentTarget );
+							}
+						} }
 					>
 						<Comp
 							{ ...rest }
-							onPointerDown={ ( evt ) => {
-								if ( ! isSelected ) {
-									handleSelectElement( id, evt );
-									// Setting target directly works, however, it doesn't get updated information from the selected elements state.
-									// setTargetEl( evt.currentTarget );
-								}
-							} }
-							forwardedRef={ isSelected ? setTargetEl : null }
+							forwardedRef={ null }
 						/>
 					</Element>
 				);
 			} ) }
-			{ 1 === selectedElements.length && targetEl && (
 				<Movable
-					rotationAngle={ selectedElements[ 0 ].rotationAngle }
+					rotationAngle={ 1 === selectedElements.length ? selectedElements[ 0 ].rotationAngle : 0 }
 					targetEl={ targetEl }
-					type={ selectedElements[ 0 ].type }
-					x={ selectedElements[ 0 ].x }
-					y={ selectedElements[ 0 ].y }
+					type={ 1 === selectedElements.length ? selectedElements[ 0 ].type : null }
+					x={ 1 === selectedElements.length ? selectedElements[ 0 ].x : 0 }
+					y={ 1 === selectedElements.length ? selectedElements[ 0 ].y : 0 }
 				/>
-			) }
 		</Background>
 	);
 }

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -64,7 +64,7 @@ const Movable = ( props ) => {
 				setStyle( target );
 			} }
 			throttleDrag={ 0 }
-			onDragStart={ ( { set } ) => {
+			onDragStart={ ( { target, set } ) => {
 				set( frame.translate );
 			} }
 			onDragEnd={ ( { target } ) => {

--- a/assets/src/edit-story/elements/image.js
+++ b/assets/src/edit-story/elements/image.js
@@ -27,7 +27,7 @@ function Image( { src, width, height, x, y, rotationAngle, forwardedRef, onPoint
 		ref: forwardedRef,
 	};
 	return (
-		<Element { ...props } onPointerDown={ onPointerDown } />
+		<Element draggable="false" { ...props } onPointerDown={ onPointerDown } />
 	);
 }
 


### PR DESCRIPTION
The demo works b/c the sequence of events is:

* pointerdown event
* setTarget state
* re-render moveable with new target
* mousedown event -> onDragStart

TBH, looking at this sequence, it feels too fragile. And it's exactly why it fails in our case. Small-ish variation leads to the following sequence

The sequence of events:

* pointerdown event
* Update selection
* mousedown event. No onDragStart since no target is set yet
* Eventually setSelection bubbles up with forwarded ref to setTargetEl
* re-render moveable with new target

Again, at this point any way to fix it is too fragile. However, this PR fixes it, however fragile. The way it works is by:

1. Make the wrapper `Element` selectable. All events are moved there.
2. It's currently "a little" broken because I didn't move x/y/width/height properties to the element too. See "nuances" section below.
3. Instead of forwarding the ref of the final element around, this version uses `event.currentTarget`. But it could also alternatively use a `ref` resolved on the `Element` itself - it'd be just as fast.
4. `Moveable` is always created. I'm actually not sure if it's strictly necessary. So we could try to remove it. Not sure there's a strong reason to do so, however.

To confirm though. I don't really like this version. But, there could be a useful nuances here. I moved all events to the wrapper `Element`. And consequently x/y/width/height would need to be moved there too. Somehow this felt like a more predictable and simpler option. We don't need to propagate `onPointerDown`. All selected elements will always be easy to reason about since they are all implemented the same way. This should even work for non-rectangular elements.

So, I'd throw away this "fix", but let's discuss keeping wrapping element changes?
