### PR TITLE
onPointerDown selection and dragging: push starting event solution

### DIFF
--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -39,6 +39,7 @@ function Page() {
 	} = useStory();
 
 	const [ targetEl, setTargetEl ] = useState( false );
+	const [ pushEvent, setPushEvent ] = useState( null );
 
 	useEffect( () => {
 		setBackgroundClickHandler( () => clearSelection() );
@@ -51,6 +52,9 @@ function Page() {
 			selectElementById( elId );
 		}
 		evt.stopPropagation();
+
+		evt.persist();
+		setPushEvent(evt);
 	}, [ toggleElementIdInSelection, selectElementById ] );
 
 	return (
@@ -80,15 +84,14 @@ function Page() {
 					</Element>
 				);
 			} ) }
-			{ 1 === selectedElements.length && targetEl && (
 				<Movable
-					rotationAngle={ selectedElements[ 0 ].rotationAngle }
+					rotationAngle={ 1 === selectedElements.length ? selectedElements[ 0 ].rotationAngle : 0 }
 					targetEl={ targetEl }
-					type={ selectedElements[ 0 ].type }
-					x={ selectedElements[ 0 ].x }
-					y={ selectedElements[ 0 ].y }
+					pushEvent={ pushEvent }
+					type={ 1 === selectedElements.length ? selectedElements[ 0 ].type : null }
+					x={ 1 === selectedElements.length ? selectedElements[ 0 ].x : 0 }
+					y={ 1 === selectedElements.length ? selectedElements[ 0 ].y : 0 }
 				/>
-			) }
 		</Background>
 	);
 }

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -21,6 +21,7 @@ const Movable = ( props ) => {
 		y,
 		type,
 		targetEl,
+		pushEvent,
 	} = props;
 
 	const moveable = useRef();
@@ -31,6 +32,9 @@ const Movable = ( props ) => {
 
 	useEffect( () => {
 		if ( moveable.current ) {
+			if ( pushEvent ) {
+				moveable.current.moveable.dragStart(pushEvent);
+			}
 			moveable.current.updateRect();
 		}
 	}, [ targetEl, moveable ] );
@@ -64,7 +68,7 @@ const Movable = ( props ) => {
 				setStyle( target );
 			} }
 			throttleDrag={ 0 }
-			onDragStart={ ( { set } ) => {
+			onDragStart={ ( { target, set } ) => {
 				set( frame.translate );
 			} }
 			onDragEnd={ ( { target } ) => {

--- a/assets/src/edit-story/elements/image.js
+++ b/assets/src/edit-story/elements/image.js
@@ -27,7 +27,7 @@ function Image( { src, width, height, x, y, rotationAngle, forwardedRef, onPoint
 		ref: forwardedRef,
 	};
 	return (
-		<Element { ...props } onPointerDown={ onPointerDown } />
+		<Element draggable="false" { ...props } onPointerDown={ onPointerDown } />
 	);
 }
 


### PR DESCRIPTION
A (better?) alternative to https://github.com/dvoytenko/amp-wp/pull/1.

See why demo works and test/one-moveable doesn't in #1. This solution, instead of trying to "fix" the order of events, simply pushes the persisted "start" event. Instead of the state in this PR, we could make it part of our selection system. E.g. we store `{id, element, initEvent}`. The `Movable` is modified to use the pushed event when the target changes. It simply calls the public `dragStart` method. Seems to work very well.
